### PR TITLE
Add tox and GitHub actions configuration for integration testing

### DIFF
--- a/.github/workflows/hourly_repo_update.yml
+++ b/.github/workflows/hourly_repo_update.yml
@@ -7,8 +7,6 @@ on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   schedule:
     - cron: '0 * * * *'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      envs: |
+        - linux: demoa-noextra
+        - linux: demoa-explicit
+        - linux: demoa-extra
+        - linux: demoa-minimal
+        - linux: demob-noextra
+        - linux: demob-explicit
+        - linux: demob-extra
+        - linux: demob-minimal

--- a/assert_installed_packages.py
+++ b/assert_installed_packages.py
@@ -1,0 +1,16 @@
+import sys
+import importlib
+
+for check in sys.argv[1:]:
+    module, status = check.split('=')
+    status = int(status)
+    try:
+        importlib.import_module(module)
+    except ImportError:
+        if status == 1:
+            print(f"{module} was not installed but was expected")
+            sys.exit(1)
+    else:
+        if status == 0:
+            print(f"{module} was installed but was not expected")
+            sys.exit(1)

--- a/demoA/pyproject.toml
+++ b/demoA/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
-# requires = [
-#     "setuptools @ git+https://github.com/wheel-next/setuptools.git#egg=pep/pep_771",
-# ]
-requires = ["setuptools @ git+file:///workspace/setuptools"]
+requires = [
+    "setuptools @ git+https://github.com/wheel-next/setuptools.git@pep_771",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]

--- a/demoB/pyproject.toml
+++ b/demoB/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
-# requires = [
-#     "setuptools @ git+https://github.com/wheel-next/setuptools.git#egg=pep/pep_771",
-# ]
-requires = ["setuptools @ git+file:///workspace/setuptools"]
+requires = [
+    "setuptools @ git+https://github.com/wheel-next/setuptools.git@pep_771",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,29 @@
+[tox]
+envlist =
+   {demoa,demob}-{noextra, explicit,extra,minimal}
+
+[testenv]
+changedir = .tmp/{envname}
+skip_install = true
+deps =
+    file://{toxinidir}/pep_771
+commands =
+
+    {list_dependencies_command}
+    python -m pip --version
+
+   demoa-noextra: python -m pip install "pep-771-demo-a @ file://{toxinidir}/demoA"
+   demoa-explicit: python -m pip install "pep-771-demo-a[flask] @ file://{toxinidir}/demoA"
+   demoa-extra: python -m pip install "pep-771-demo-a[fastapi] @ file://{toxinidir}/demoA"
+   demoa-minimal: python -m pip install "pep-771-demo-a[minimal] @ file://{toxinidir}/demoA"
+   demob-noextra: python -m pip install "pep-771-demo-b @ file://{toxinidir}/demoB"
+   demob-explicit: python -m pip install "pep-771-demo-b[flask] @ file://{toxinidir}/demoB"
+   demob-extra: python -m pip install "pep-771-demo-b[fastapi] @ file://{toxinidir}/demoB"
+   demob-minimal: python -m pip install "pep-771-demo-b[minimal] @ file://{toxinidir}/demoB"
+
+    {list_dependencies_command}
+
+    noextra: python {toxinidir}/assert_installed_packages.py flask=1 fastapi=0
+    explicit: python {toxinidir}/assert_installed_packages.py flask=1 fastapi=0
+    extra: python {toxinidir}/assert_installed_packages.py flask=0 fastapi=1
+    minimal: python {toxinidir}/assert_installed_packages.py flask=0 fastapi=0


### PR DESCRIPTION
This adjusts some of the testing infrastructure I had in my demo to work here. If you run:

```
tox
```

(or ``tox -p all``), it will run all the different use cases in isolated environments automatically, then check if the correct dependencies have been installed. I've also included a GitHub actions config to automatically run this on PRs and pushes.

I switched the URLs for setuptools in demoA and demoB as the workspace version didn't work for me (and won't work on GitHub actions).