### PR TITLE
Add more tox environments to check different scenarios

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,11 @@ jobs:
         - linux: demoa-explicit
         - linux: demoa-extra
         - linux: demoa-minimal
+        - linux: demoa-double
+        - linux: demoa-doublename
         - linux: demob-noextra
         - linux: demob-explicit
         - linux: demob-extra
         - linux: demob-minimal
+        - linux: demob-double
+        - linux: demob-doublename

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
 envlist =
-   {demoa,demob}-{noextra, explicit,extra,minimal}
+   {demoa,demob}-{noextra, explicit,extra,minimal,double,doublename}
 
 [testenv]
 changedir = .tmp/{envname}
 skip_install = true
+recreate = true
 deps =
     file://{toxinidir}/pep_771
 commands =
@@ -21,9 +22,23 @@ commands =
    demob-extra: python -m pip install "pep-771-demo-b[fastapi] @ file://{toxinidir}/demoB"
    demob-minimal: python -m pip install "pep-771-demo-b\[\] @ file://{toxinidir}/demoB"
 
+    # Install the package opting out of default extras, then reinstall with no
+    # explicit extras. The defaults should be installed on the second call even
+    # though the package is already present. The double factor reinstalls via the
+    # same file:// URL; doublename reinstalls via a bare name spec, which exercises
+    # the already-installed candidate path in pip's resolver.
+   demoa-double: python -m pip install "pep-771-demo-a\[\] @ file://{toxinidir}/demoA"
+   demoa-double: python -m pip install "pep-771-demo-a @ file://{toxinidir}/demoA"
+   demob-double: python -m pip install "pep-771-demo-b\[\] @ file://{toxinidir}/demoB"
+   demob-double: python -m pip install "pep-771-demo-b @ file://{toxinidir}/demoB"
+
+   demoa-doublename: python -m pip install "pep-771-demo-a\[\] @ file://{toxinidir}/demoA"
+   demoa-doublename: python -m pip install pep-771-demo-a
+   demob-doublename: python -m pip install "pep-771-demo-b\[\] @ file://{toxinidir}/demoB"
+   demob-doublename: python -m pip install pep-771-demo-b
+
     {list_dependencies_command}
 
-    noextra: python {toxinidir}/assert_installed_packages.py flask=1 fastapi=0
-    explicit: python {toxinidir}/assert_installed_packages.py flask=1 fastapi=0
+    noextra,explicit,double,doublename: python {toxinidir}/assert_installed_packages.py flask=1 fastapi=0
     extra: python {toxinidir}/assert_installed_packages.py flask=0 fastapi=1
     minimal: python {toxinidir}/assert_installed_packages.py flask=0 fastapi=0


### PR DESCRIPTION
This ensures that ``pip install package[]`` installs the minimal version of packages, and that doing:

```
pip install package[]
pip install package
```

will make sure default extras end up being installed.